### PR TITLE
test: add nil checks

### DIFF
--- a/tests/checkandmutaterow_test.go
+++ b/tests/checkandmutaterow_test.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !emulator
 // +build !emulator
 
 package tests
@@ -99,7 +100,7 @@ func TestCheckAndMutateRow_Generic_Headers(t *testing.T) {
 	}
 
 	resource := md["x-goog-request-params"][0]
-        if !strings.Contains(resource, tableName) && !strings.Contains(resource, url.QueryEscape(tableName)) {
+	if !strings.Contains(resource, tableName) && !strings.Contains(resource, url.QueryEscape(tableName)) {
 		assert.Fail(t, "Resource info is missing in the request header")
 	}
 	assert.Contains(t, resource, profileID)
@@ -121,7 +122,7 @@ func TestCheckAndMutateRow_NoRetry_TrueMutations(t *testing.T) {
 	// 2. Build the request to test proxy
 	req := testproxypb.CheckAndMutateRowRequest{
 		ClientId: t.Name(),
-		Request: clientReq,
+		Request:  clientReq,
 	}
 
 	// 3. Perform the operation via test proxy
@@ -181,7 +182,7 @@ func TestCheckAndMutateRow_Generic_MultiStreams(t *testing.T) {
 	for i := 0; i < concurrency; i++ {
 		actions[i] = &checkAndMutateRowAction{
 			predicateMatched: predicateMatched[i],
-			delayStr: "2s",
+			delayStr:         "2s",
 		}
 	}
 	server := initMockServer(t)
@@ -256,12 +257,12 @@ func TestCheckAndMutateRow_Generic_CloseClient(t *testing.T) {
 
 	// 1. Instantiate the mock server
 	recorder := make(chan *checkAndMutateRowReqRecord, requestRecorderCapacity)
-	actions := make([]*checkAndMutateRowAction, 2 * halfBatchSize)
-	for i := 0; i < 2 * halfBatchSize; i++ {
+	actions := make([]*checkAndMutateRowAction, 2*halfBatchSize)
+	for i := 0; i < 2*halfBatchSize; i++ {
 		// Each request will get a different response.
 		actions[i] = &checkAndMutateRowAction{
 			predicateMatched: predicateMatched[i],
-			delayStr: "2s",
+			delayStr:         "2s",
 		}
 	}
 	server := initMockServer(t)
@@ -273,12 +274,12 @@ func TestCheckAndMutateRow_Generic_CloseClient(t *testing.T) {
 	for i := 0; i < halfBatchSize; i++ {
 		reqsBatchOne[i] = &testproxypb.CheckAndMutateRowRequest{
 			ClientId: clientID,
-			Request: dummyCheckAndMutateRowRequest("table", []byte(rowKeys[i]), predicateMatched[i], 1),
+			Request:  dummyCheckAndMutateRowRequest("table", []byte(rowKeys[i]), predicateMatched[i], 1),
 		}
 		reqsBatchTwo[i] = &testproxypb.CheckAndMutateRowRequest{
-			ClientId:  clientID,
+			ClientId: clientID,
 			Request: dummyCheckAndMutateRowRequest(
-				"table", []byte(rowKeys[i + halfBatchSize]), predicateMatched[i + halfBatchSize], 1),
+				"table", []byte(rowKeys[i+halfBatchSize]), predicateMatched[i+halfBatchSize], 1),
 		}
 	}
 
@@ -296,6 +297,10 @@ func TestCheckAndMutateRow_Generic_CloseClient(t *testing.T) {
 	// 4b. Check that all the batch-one requests succeeded
 	checkResultOkStatus(t, resultsBatchOne...)
 	for i := 0; i < halfBatchSize; i++ {
+		assert.NotNil(t, resultsBatchOne[i].Result)
+		if resultsBatchOne[i].Result == nil {
+			continue
+		}
 		assert.Equal(t, predicateMatched[i], resultsBatchOne[i].Result.PredicateMatched)
 	}
 
@@ -320,7 +325,7 @@ func TestCheckAndMutateRow_Generic_DeadlineExceeded(t *testing.T) {
 	recorder := make(chan *checkAndMutateRowReqRecord, 1)
 	action := &checkAndMutateRowAction{
 		predicateMatched: predicateMatched,
-		delayStr: "10s",
+		delayStr:         "10s",
 	}
 	server := initMockServer(t)
 	server.CheckAndMutateRowFn = mockCheckAndMutateRowFnSimple(recorder, action)
@@ -328,7 +333,7 @@ func TestCheckAndMutateRow_Generic_DeadlineExceeded(t *testing.T) {
 	// 2. Build the request to test proxy
 	req := testproxypb.CheckAndMutateRowRequest{
 		ClientId: t.Name(),
-		Request: dummyCheckAndMutateRowRequest("table", []byte("row-01"), predicateMatched, 2),
+		Request:  dummyCheckAndMutateRowRequest("table", []byte("row-01"), predicateMatched, 2),
 	}
 
 	// 3. Perform the operation via test proxy
@@ -347,4 +352,3 @@ func TestCheckAndMutateRow_Generic_DeadlineExceeded(t *testing.T) {
 	// 4b. Check the DeadlineExceeded error
 	assert.Equal(t, int32(codes.DeadlineExceeded), res.GetStatus().GetCode())
 }
-

--- a/tests/checkandmutaterow_test.go
+++ b/tests/checkandmutaterow_test.go
@@ -211,6 +211,14 @@ func TestCheckAndMutateRow_Generic_MultiStreams(t *testing.T) {
 
 	// 4c. Check the results.
 	for i := 0; i < concurrency; i++ {
+		assert.NotNil(t, results[i])
+		if results[i] == nil {
+			continue
+		}
+		assert.NotNil(t, results[i].Result)
+		if results[i].Result == nil {
+			continue
+		}
 		assert.Equal(t, predicateMatched[i], results[i].Result.PredicateMatched)
 	}
 }

--- a/tests/mutaterow_test.go
+++ b/tests/mutaterow_test.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !emulator
 // +build !emulator
 
 package tests
@@ -42,7 +43,7 @@ import (
 func dummyMutateRowRequest(tableID string, rowKey []byte, numMutations int) *btpb.MutateRowRequest {
 	req := &btpb.MutateRowRequest{
 		TableName: buildTableName(tableID),
-		RowKey: rowKey,
+		RowKey:    rowKey,
 		Mutations: []*btpb.Mutation{},
 	}
 	for i := 0; i < numMutations; i++ {
@@ -99,7 +100,7 @@ func TestMutateRow_Generic_Headers(t *testing.T) {
 	}
 
 	resource := md["x-goog-request-params"][0]
-        if !strings.Contains(resource, tableName) && !strings.Contains(resource, url.QueryEscape(tableName)) {
+	if !strings.Contains(resource, tableName) && !strings.Contains(resource, url.QueryEscape(tableName)) {
 		assert.Fail(t, "Resource info is missing in the request header")
 	}
 	assert.Contains(t, resource, profileID)
@@ -147,7 +148,7 @@ func TestMutateRow_NoRetry_MultipleMutations(t *testing.T) {
 	// 2. Build the request to test proxy
 	req := testproxypb.MutateRowRequest{
 		ClientId: t.Name(),
-		Request: clientReq,
+		Request:  clientReq,
 	}
 
 	// 3. Perform the operation via test proxy
@@ -212,8 +213,8 @@ func TestMutateRow_Generic_CloseClient(t *testing.T) {
 
 	// 1. Instantiate the mock server
 	recorder := make(chan *mutateRowReqRecord, requestRecorderCapacity)
-	actions := make([]*mutateRowAction, 2 * halfBatchSize)
-	for i := 0; i < 2 * halfBatchSize; i++ {
+	actions := make([]*mutateRowAction, 2*halfBatchSize)
+	for i := 0; i < 2*halfBatchSize; i++ {
 		actions[i] = &mutateRowAction{delayStr: "2s"}
 	}
 	server := initMockServer(t)
@@ -225,11 +226,11 @@ func TestMutateRow_Generic_CloseClient(t *testing.T) {
 	for i := 0; i < halfBatchSize; i++ {
 		reqsBatchOne[i] = &testproxypb.MutateRowRequest{
 			ClientId: clientID,
-			Request: dummyMutateRowRequest("table", []byte(rowKeys[i]), 1),
+			Request:  dummyMutateRowRequest("table", []byte(rowKeys[i]), 1),
 		}
 		reqsBatchTwo[i] = &testproxypb.MutateRowRequest{
 			ClientId: clientID,
-			Request: dummyMutateRowRequest("table", []byte(rowKeys[i + halfBatchSize]), 1),
+			Request:  dummyMutateRowRequest("table", []byte(rowKeys[i+halfBatchSize]), 1),
 		}
 	}
 
@@ -269,7 +270,7 @@ func TestMutateRow_Generic_DeadlineExceeded(t *testing.T) {
 	// 2. Build the request to test proxy
 	req := testproxypb.MutateRowRequest{
 		ClientId: t.Name(),
-		Request: dummyMutateRowRequest("table", []byte("row-01"), 2),
+		Request:  dummyMutateRowRequest("table", []byte("row-01"), 2),
 	}
 
 	// 3. Perform the operation via test proxy
@@ -288,4 +289,3 @@ func TestMutateRow_Generic_DeadlineExceeded(t *testing.T) {
 	// 4b. Check the DeadlineExceeded error
 	assert.Equal(t, int32(codes.DeadlineExceeded), res.GetStatus().GetCode())
 }
-

--- a/tests/readmodifywriterow_test.go
+++ b/tests/readmodifywriterow_test.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !emulator
 // +build !emulator
 
 package tests
@@ -41,7 +42,7 @@ func dummyReadModifyWriteRowRequest(tableID string, rowKey []byte, increments []
 	req := &btpb.ReadModifyWriteRowRequest{
 		TableName: buildTableName(tableID),
 		RowKey:    rowKey,
-		Rules:	   []*btpb.ReadModifyWriteRule{},
+		Rules:     []*btpb.ReadModifyWriteRule{},
 	}
 
 	i := 0
@@ -91,7 +92,7 @@ func dummyResultRow(rowKey []byte, increments []int64, appends []string) *btpb.R
 	}
 
 	row := &btpb.Row{
-		Key:      rowKey,
+		Key: rowKey,
 		Families: []*btpb.Family{
 			&btpb.Family{
 				Name: "f",
@@ -136,7 +137,7 @@ func TestReadModifyWriteRow_Generic_Headers(t *testing.T) {
 	// 2. Build the request to test proxy
 	req := testproxypb.ReadModifyWriteRowRequest{
 		ClientId: t.Name(),
-		Request: dummyReadModifyWriteRowRequest(tableID, rowKey, increments, appends),
+		Request:  dummyReadModifyWriteRowRequest(tableID, rowKey, increments, appends),
 	}
 
 	// 3. Perform the operation via test proxy
@@ -152,7 +153,7 @@ func TestReadModifyWriteRow_Generic_Headers(t *testing.T) {
 	}
 
 	resource := md["x-goog-request-params"][0]
-        if !strings.Contains(resource, tableName) && !strings.Contains(resource, url.QueryEscape(tableName)) {
+	if !strings.Contains(resource, tableName) && !strings.Contains(resource, url.QueryEscape(tableName)) {
 		assert.Fail(t, "Resource info is missing in the request header")
 	}
 	assert.Contains(t, resource, profileID)
@@ -188,8 +189,8 @@ func TestReadModifyWriteRow_NoRetry_MultiValues(t *testing.T) {
 		t.Errorf("diff found (-want +got):\n%s", diff)
 	}
 	assert.Equal(t, rowKey, res.Row.Key)
-	assert.Equal(t, 10 + 2, int(binary.BigEndian.Uint64(res.Row.Families[0].Columns[0].Cells[0].Value)))
-	assert.Equal(t, "str1" + "str2", string(res.Row.Families[0].Columns[1].Cells[0].Value))
+	assert.Equal(t, 10+2, int(binary.BigEndian.Uint64(res.Row.Families[0].Columns[0].Cells[0].Value)))
+	assert.Equal(t, "str1"+"str2", string(res.Row.Families[0].Columns[1].Cells[0].Value))
 }
 
 // TestReadModifyWriteRow_Generic_MultiStreams tests that client can have multiple concurrent streams.
@@ -206,7 +207,7 @@ func TestReadModifyWriteRow_Generic_MultiStreams(t *testing.T) {
 	actions := make([]*readModifyWriteRowAction, concurrency)
 	for i := 0; i < concurrency; i++ {
 		actions[i] = &readModifyWriteRowAction{
-			row: dummyResultRow([]byte(rowKeys[i]), increments, appends),
+			row:      dummyResultRow([]byte(rowKeys[i]), increments, appends),
 			delayStr: "2s"}
 	}
 	server := initMockServer(t)
@@ -284,10 +285,10 @@ func TestReadModifyWriteRow_Generic_CloseClient(t *testing.T) {
 
 	// 1. Instantiate the mock server
 	recorder := make(chan *readModifyWriteRowReqRecord, requestRecorderCapacity)
-	actions := make([]*readModifyWriteRowAction, 2 * halfBatchSize)
-	for i := 0; i < 2 * halfBatchSize; i++ {
+	actions := make([]*readModifyWriteRowAction, 2*halfBatchSize)
+	for i := 0; i < 2*halfBatchSize; i++ {
 		actions[i] = &readModifyWriteRowAction{
-			row: dummyResultRow([]byte(rowKeys[i]), increments, appends),
+			row:      dummyResultRow([]byte(rowKeys[i]), increments, appends),
 			delayStr: "2s",
 		}
 	}
@@ -300,12 +301,12 @@ func TestReadModifyWriteRow_Generic_CloseClient(t *testing.T) {
 	for i := 0; i < halfBatchSize; i++ {
 		reqsBatchOne[i] = &testproxypb.ReadModifyWriteRowRequest{
 			ClientId: clientID,
-			Request: dummyReadModifyWriteRowRequest("table", []byte(rowKeys[i]), increments, appends),
+			Request:  dummyReadModifyWriteRowRequest("table", []byte(rowKeys[i]), increments, appends),
 		}
 		reqsBatchTwo[i] = &testproxypb.ReadModifyWriteRowRequest{
-			ClientId:  clientID,
+			ClientId: clientID,
 			Request: dummyReadModifyWriteRowRequest(
-				"table", []byte(rowKeys[i + halfBatchSize]), increments, appends),
+				"table", []byte(rowKeys[i+halfBatchSize]), increments, appends),
 		}
 	}
 
@@ -323,6 +324,10 @@ func TestReadModifyWriteRow_Generic_CloseClient(t *testing.T) {
 	// 4b. Check that all the batch-one requests succeeded
 	checkResultOkStatus(t, resultsBatchOne...)
 	for i := 0; i < halfBatchSize; i++ {
+		assert.NotNil(t, resultsBatchOne[i])
+		if resultsBatchOne[i] == nil {
+			continue
+		}
 		assert.Equal(t, rowKeys[i], string(resultsBatchOne[i].Row.Key))
 	}
 
@@ -349,7 +354,7 @@ func TestReadModifyWriteRow_Generic_DeadlineExceeded(t *testing.T) {
 	// 1. Instantiate the mock server
 	recorder := make(chan *readModifyWriteRowReqRecord, 1)
 	action := &readModifyWriteRowAction{
-		row: dummyResultRow(rowKey, increments, appends),
+		row:      dummyResultRow(rowKey, increments, appends),
 		delayStr: "10s",
 	}
 	server := initMockServer(t)
@@ -358,7 +363,7 @@ func TestReadModifyWriteRow_Generic_DeadlineExceeded(t *testing.T) {
 	// 2. Build the request to test proxy
 	req := testproxypb.ReadModifyWriteRowRequest{
 		ClientId: t.Name(),
-		Request: clientReq,
+		Request:  clientReq,
 	}
 
 	// 3. Perform the operation via test proxy
@@ -377,4 +382,3 @@ func TestReadModifyWriteRow_Generic_DeadlineExceeded(t *testing.T) {
 	// 4b. Check the DeadlineExceeded error
 	assert.Equal(t, int32(codes.DeadlineExceeded), res.GetStatus().GetCode())
 }
-

--- a/tests/readmodifywriterow_test.go
+++ b/tests/readmodifywriterow_test.go
@@ -236,6 +236,14 @@ func TestReadModifyWriteRow_Generic_MultiStreams(t *testing.T) {
 
 	// 4c. Check the row keys in the results.
 	for i := 0; i < concurrency; i++ {
+		assert.NotNil(t, results[i])
+		if results[i] == nil {
+			continue
+		}
+		assert.NotNil(t, results[i].Row)
+		if results[i].Row == nil {
+			continue
+		}
 		assert.Equal(t, rowKeys[i], string(results[i].Row.Key))
 	}
 }


### PR DESCRIPTION
Without these nil checks, the test panics and further tests are not run. E.g.:
```
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x150ed49]

goroutine 93 [running]:
testing.tRunner.func1.2({0x15a7020, 0x1ad7d40})
	/usr/local/go/src/testing/testing.go:1526 +0x24e
testing.tRunner.func1()
	/usr/local/go/src/testing/testing.go:1529 +0x39f
panic({0x15a7020, 0x1ad7d40})
	/usr/local/go/src/runtime/panic.go:884 +0x213
github.com/googleapis/cloud-bigtable-clients-test/tests.TestCheckAndMutateRow_Generic_CloseClient(0xc00041c000)
	*****************************/cloud-bigtable-clients-test/tests/checkandmutaterow_test.go:299 +0x669
testing.tRunner(0xc00041c000, 0x16990d0)
	/usr/local/go/src/testing/testing.go:1576 +0x10b
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1629 +0x3ea
exit status 2
```