### PR TITLE
feat: add a test for routing cookie

### DIFF
--- a/tests/mock_helper.go
+++ b/tests/mock_helper.go
@@ -171,8 +171,6 @@ func mockReadRowsFnWithMetadata(recorder chan<- *readRowsReqRecord, mdRecorder c
 			}
 			sleepFor(action.delayStr)
 
-			// TODO: for retry info, we can use gs.ErrorProto(Status) where Status has a ErrorDetails
-			// https://pkg.go.dev/google.golang.org/grpc/status#ErrorProto
 			if action.rpcError != codes.OK {
 				if action.routingCookie != "" {
 					// add routing cookie to metadata

--- a/tests/mock_helper.go
+++ b/tests/mock_helper.go
@@ -26,8 +26,8 @@ import (
 	btpb "google.golang.org/genproto/googleapis/bigtable/v2"
 	"google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/grpc/codes"
-	gs "google.golang.org/grpc/status"
 	"google.golang.org/grpc/metadata"
+	gs "google.golang.org/grpc/status"
 )
 
 var rowKeyPrefixRegex = regexp.MustCompile("^op[0-9]+-")
@@ -120,10 +120,6 @@ func mockReadRowsFnSimple(recorder chan<- *readRowsReqRecord, actions ...*readRo
 
 func mockReadRowsFn(recorder chan<- *readRowsReqRecord, actionSequences ...[]*readRowsAction) func(*btpb.ReadRowsRequest, btpb.Bigtable_ReadRowsServer) error {
 	return mockReadRowsFnWithMetadata(recorder, nil, actionSequences...)
-}
-
-func mockReadRowsMetadataFn(mdRecorder chan metadata.MD, actionSequences ...[]*readRowsAction) func(*btpb.ReadRowsRequest, btpb.Bigtable_ReadRowsServer) error {
-	return mockReadRowsFnWithMetadata(nil, mdRecorder, actionSequences...)
 }
 
 // mockReadRowsFn returns a mock implementation of server-side ReadRows(). The behavior is

--- a/tests/readrows_test.go
+++ b/tests/readrows_test.go
@@ -792,7 +792,7 @@ func TestReadRows_Generic_DeadlineExceeded(t *testing.T) {
 }
 
 // TestReadRows_Generic_RetryWithRoutingCookie tests that routing cookie is handled correctly by the client.
-func TestReadRows_Generic_RetryWithRoutingCookie(t *testing.T) {
+func TestReadRows_Retry_WithRoutingCookie(t *testing.T) {
 	// 0. Common variable
 	cookie := "test-cookie"
 

--- a/tests/readrows_test.go
+++ b/tests/readrows_test.go
@@ -791,7 +791,7 @@ func TestReadRows_Generic_DeadlineExceeded(t *testing.T) {
 	}
 }
 
-// TestReadRows_Generic_RetryWithRoutingCookie tests that routing cookie is handled correctly by the client.
+// TestReadRows_Retry_WithRoutingCookie tests that routing cookie is handled correctly by the client.
 func TestReadRows_Retry_WithRoutingCookie(t *testing.T) {
 	// 0. Common variable
 	cookie := "test-cookie"

--- a/tests/test_datatype.go
+++ b/tests/test_datatype.go
@@ -91,11 +91,13 @@ type chunkData struct {
 //     Effect: server will return an error. chunks that are specified in the same action will be ignored.
 //  4. readRowsAction{rpcError: error, delayStr: delay}
 //     Effect: server will return an error after delay. chunks that are specified in the same action will be ignored.
-//  5. To have a response stream with/without errors, a sequence of actions should be constructed.
+//  5. readRowsAction{rpcError: error, routingCookie: cookie
+//     Effect: server will return an error with the routing cookie. Retry attempt header should have this cookie.
+//  6. To have a response stream with/without errors, a sequence of actions should be constructed.
 type readRowsAction struct {
-	chunks   []chunkData
-	rpcError codes.Code
-	delayStr string  // "" means zero delay; follow https://pkg.go.dev/time#ParseDuration otherwise
+	chunks        []chunkData
+	rpcError      codes.Code
+	delayStr      string  // "" means zero delay; follow https://pkg.go.dev/time#ParseDuration otherwise
 	routingCookie string
 }
 func (a *readRowsAction) Validate() {

--- a/tests/test_datatype.go
+++ b/tests/test_datatype.go
@@ -91,7 +91,7 @@ type chunkData struct {
 //     Effect: server will return an error. chunks that are specified in the same action will be ignored.
 //  4. readRowsAction{rpcError: error, delayStr: delay}
 //     Effect: server will return an error after delay. chunks that are specified in the same action will be ignored.
-//  5. readRowsAction{rpcError: error, routingCookie: cookie
+//  5. readRowsAction{rpcError: error, routingCookie: cookie}
 //     Effect: server will return an error with the routing cookie. Retry attempt header should have this cookie.
 //  6. To have a response stream with/without errors, a sequence of actions should be constructed.
 type readRowsAction struct {

--- a/tests/test_datatype.go
+++ b/tests/test_datatype.go
@@ -96,6 +96,7 @@ type readRowsAction struct {
 	chunks   []chunkData
 	rpcError codes.Code
 	delayStr string  // "" means zero delay; follow https://pkg.go.dev/time#ParseDuration otherwise
+	routingCookie string
 }
 func (a *readRowsAction) Validate() {
 	for _, chunk := range a.chunks {


### PR DESCRIPTION
Add a routing cookie test to ReadRows.

Server returns a cookie with an error response. Client will add this cookie to the header of the retry attempt. This test checks that retries are handled correctly with stream resumption when a cookie is present and cookie is added to the header.