### PR TITLE
test: Make close client tests more generic

### DIFF
--- a/tests/checkandmutaterow_test.go
+++ b/tests/checkandmutaterow_test.go
@@ -302,9 +302,13 @@ func TestCheckAndMutateRow_Generic_CloseClient(t *testing.T) {
 	// 4a. Check that server only receives batch-one requests
 	assert.Equal(t, halfBatchSize, len(recorder))
 
-	// 4b. Check that all the batch-one requests succeeded
-	checkResultOkStatus(t, resultsBatchOne...)
+	// 4b. Check that all the batch-one requests succeeded or were cancelled
+	checkResultOkOrCancelledStatus(t, resultsBatchOne...)
 	for i := 0; i < halfBatchSize; i++ {
+		resCode := resultsBatchOne[i].GetStatus().GetCode()
+		if resCode == int32(codes.Canceled) {
+			continue
+		}
 		assert.NotNil(t, resultsBatchOne[i].Result)
 		if resultsBatchOne[i].Result == nil {
 			continue

--- a/tests/mutaterow_test.go
+++ b/tests/mutaterow_test.go
@@ -246,7 +246,7 @@ func TestMutateRow_Generic_CloseClient(t *testing.T) {
 	assert.Equal(t, halfBatchSize, len(recorder))
 
 	// 4b. Check that all the batch-one requests succeeded
-	checkResultOkStatus(t, resultsBatchOne...)
+	checkResultOkOrCancelledStatus(t, resultsBatchOne...)
 
 	// 4c. Check that all the batch-two requests failed at the proxy level:
 	// the proxy tries to use close client. Client and server have nothing to blame.

--- a/tests/readmodifywriterow_test.go
+++ b/tests/readmodifywriterow_test.go
@@ -329,11 +329,15 @@ func TestReadModifyWriteRow_Generic_CloseClient(t *testing.T) {
 	// 4a. Check that server only receives batch-one requests
 	assert.Equal(t, halfBatchSize, len(recorder))
 
-	// 4b. Check that all the batch-one requests succeeded
-	checkResultOkStatus(t, resultsBatchOne...)
+	// 4b. Check that all the batch-one requests succeeded or were cancelled
+	checkResultOkOrCancelledStatus(t, resultsBatchOne...)
 	for i := 0; i < halfBatchSize; i++ {
 		assert.NotNil(t, resultsBatchOne[i])
 		if resultsBatchOne[i] == nil {
+			continue
+		}
+		resCode := resultsBatchOne[i].GetStatus().GetCode()
+		if resCode == int32(codes.Canceled) {
 			continue
 		}
 		assert.Equal(t, rowKeys[i], string(resultsBatchOne[i].Row.Key))

--- a/tests/readrow_test.go
+++ b/tests/readrow_test.go
@@ -287,11 +287,15 @@ func TestReadRow_Generic_CloseClient(t *testing.T) {
 	// 4a. Check that server only receives batch-one requests
 	assert.Equal(t, halfBatchSize, len(recorder))
 
-	// 4b. Check that all the batch-one requests succeeded
-	checkResultOkStatus(t, resultsBatchOne...)
+	// 4b. Check that all the batch-one requests succeeded or were cancelled
+	checkResultOkOrCancelledStatus(t, resultsBatchOne...)
 	for i := 0; i < halfBatchSize; i++ {
 		assert.NotNil(t, resultsBatchOne[i])
 		if resultsBatchOne[i] == nil {
+			continue
+		}
+		resCode := resultsBatchOne[i].GetStatus().GetCode()
+		if resCode == int32(codes.Canceled) {
 			continue
 		}
 		assert.NotNil(t, resultsBatchOne[i].Row)

--- a/tests/test_workflow.go
+++ b/tests/test_workflow.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	btpb "google.golang.org/genproto/googleapis/bigtable/v2"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/proto"
 )
@@ -596,6 +597,16 @@ func checkResultOkStatus[R anyResult](t *testing.T, results ...R) {
 	for _, res := range results {
 		assert.NotEmpty(t, res)
 		assert.Empty(t, res.GetStatus().GetCode())
+	}
+}
+
+// checkResultOkOrCancelledStatus checks if the results have ok or cancelled status. The result type can be any of those
+// supported by the test proxy.
+func checkResultOkOrCancelledStatus[R anyResult](t *testing.T, results ...R) {
+	for _, res := range results {
+		assert.NotEmpty(t, res)
+		resCode := res.GetStatus().GetCode()
+		assert.True(t, resCode == int32(codes.OK) || resCode == int32(codes.Canceled))
 	}
 }
 


### PR DESCRIPTION
Fixes: b/322202955
Different clients have different behaviors when closing the client. For Java, it waits for the in-flight requests to finish. For Go, it kills the in-flight requests and throws an exception. Currently the conformance test expect the client to wait for requests to finish. We can make it more generic to verify that the requests are killed either way (wait for finish or throw exception) instead of left unresolved.

When the tests are run against Go proxy:
**Logs before**:
```
=== RUN   TestCheckAndMutateRow_Generic_CloseClient
[Servr log] 2024/03/18 21:24:11 There is 2s sleep on the server side
[Servr log] 2024/03/18 21:24:11 There is 2s sleep on the server side
[Servr log] 2024/03/18 21:24:11 There is 2s sleep on the server side
    test_workflow.go:598: 
        	Error Trace:	*******/cloud-bigtable-clients-test/tests/test_workflow.go:598
        	            				*******/cloud-bigtable-clients-test/tests/checkandmutaterow_test.go:306
        	Error:      	Should be empty, but was 1
        	Test:       	TestCheckAndMutateRow_Generic_CloseClient
    test_workflow.go:598: 
        	Error Trace:	*******/cloud-bigtable-clients-test/tests/test_workflow.go:598
        	            				*******/cloud-bigtable-clients-test/tests/checkandmutaterow_test.go:306
        	Error:      	Should be empty, but was 1
        	Test:       	TestCheckAndMutateRow_Generic_CloseClient
    test_workflow.go:598: 
        	Error Trace:	*******/cloud-bigtable-clients-test/tests/test_workflow.go:598
        	            				*******/cloud-bigtable-clients-test/tests/checkandmutaterow_test.go:306
        	Error:      	Should be empty, but was 1
        	Test:       	TestCheckAndMutateRow_Generic_CloseClient
    checkandmutaterow_test.go:308: 
        	Error Trace:	*******/cloud-bigtable-clients-test/tests/checkandmutaterow_test.go:308
        	Error:      	Expected value not to be nil.
        	Test:       	TestCheckAndMutateRow_Generic_CloseClient
    checkandmutaterow_test.go:308: 
        	Error Trace:	*******/cloud-bigtable-clients-test/tests/checkandmutaterow_test.go:308
        	Error:      	Expected value not to be nil.
        	Test:       	TestCheckAndMutateRow_Generic_CloseClient
    checkandmutaterow_test.go:308: 
        	Error Trace:	*******/cloud-bigtable-clients-test/tests/checkandmutaterow_test.go:308
        	Error:      	Expected value not to be nil.
        	Test:       	TestCheckAndMutateRow_Generic_CloseClient
--- FAIL: TestCheckAndMutateRow_Generic_CloseClient (1.01s)
=== RUN   TestMutateRow_Generic_CloseClient
[Servr log] 2024/03/18 21:24:12 There is 2s sleep on the server side
[Servr log] 2024/03/18 21:24:12 There is 2s sleep on the server side
[Servr log] 2024/03/18 21:24:12 There is 2s sleep on the server side
    test_workflow.go:598: 
        	Error Trace:	*******/cloud-bigtable-clients-test/tests/test_workflow.go:598
        	            				*******/cloud-bigtable-clients-test/tests/mutaterow_test.go:249
        	Error:      	Should be empty, but was 1
        	Test:       	TestMutateRow_Generic_CloseClient
    test_workflow.go:598: 
        	Error Trace:	*******/cloud-bigtable-clients-test/tests/test_workflow.go:598
        	            				*******/cloud-bigtable-clients-test/tests/mutaterow_test.go:249
        	Error:      	Should be empty, but was 1
        	Test:       	TestMutateRow_Generic_CloseClient
    test_workflow.go:598: 
        	Error Trace:	*******/cloud-bigtable-clients-test/tests/test_workflow.go:598
        	            				*******/cloud-bigtable-clients-test/tests/mutaterow_test.go:249
        	Error:      	Should be empty, but was 1
        	Test:       	TestMutateRow_Generic_CloseClient
--- FAIL: TestMutateRow_Generic_CloseClient (1.01s)
=== RUN   TestMutateRows_Generic_CloseClient
[Servr log] 2024/03/18 21:24:13 There is 2s sleep on the server side
[Servr log] 2024/03/18 21:24:13 There is 2s sleep on the server side
[Servr log] 2024/03/18 21:24:13 There is 2s sleep on the server side
    test_workflow.go:598: 
        	Error Trace:	*******/cloud-bigtable-clients-test/tests/test_workflow.go:598
        	            				*******/cloud-bigtable-clients-test/tests/mutaterows_test.go:453
        	Error:      	Should be empty, but was 1
        	Test:       	TestMutateRows_Generic_CloseClient
    test_workflow.go:598: 
        	Error Trace:	*******/cloud-bigtable-clients-test/tests/test_workflow.go:598
        	            				*******/cloud-bigtable-clients-test/tests/mutaterows_test.go:453
        	Error:      	Should be empty, but was 1
        	Test:       	TestMutateRows_Generic_CloseClient
    test_workflow.go:598: 
        	Error Trace:	*******/cloud-bigtable-clients-test/tests/test_workflow.go:598
        	            				*******/cloud-bigtable-clients-test/tests/mutaterows_test.go:453
        	Error:      	Should be empty, but was 1
        	Test:       	TestMutateRows_Generic_CloseClient
--- FAIL: TestMutateRows_Generic_CloseClient (1.01s)
=== RUN   TestReadModifyWriteRow_Generic_CloseClient
[Servr log] 2024/03/18 21:24:14 There is 2s sleep on the server side
[Servr log] 2024/03/18 21:24:14 There is 2s sleep on the server side
[Servr log] 2024/03/18 21:24:14 There is 2s sleep on the server side
    test_workflow.go:598: 
        	Error Trace:	*******/cloud-bigtable-clients-test/tests/test_workflow.go:598
        	            				*******/cloud-bigtable-clients-test/tests/readmodifywriterow_test.go:333
        	Error:      	Should be empty, but was 1
        	Test:       	TestReadModifyWriteRow_Generic_CloseClient
    test_workflow.go:598: 
        	Error Trace:	*******/cloud-bigtable-clients-test/tests/test_workflow.go:598
        	            				*******/cloud-bigtable-clients-test/tests/readmodifywriterow_test.go:333
        	Error:      	Should be empty, but was 1
        	Test:       	TestReadModifyWriteRow_Generic_CloseClient
    test_workflow.go:598: 
        	Error Trace:	*******/cloud-bigtable-clients-test/tests/test_workflow.go:598
        	            				*******/cloud-bigtable-clients-test/tests/readmodifywriterow_test.go:333
        	Error:      	Should be empty, but was 1
        	Test:       	TestReadModifyWriteRow_Generic_CloseClient
--- FAIL: TestReadModifyWriteRow_Generic_CloseClient (1.01s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x186c479]

goroutine 85 [running]:
testing.tRunner.func1.2({0x1911340, 0x1f1f2b0})
	/usr/local/go/src/testing/testing.go:1545 +0x3f7
testing.tRunner.func1()
	/usr/local/go/src/testing/testing.go:1548 +0x716
panic({0x1911340?, 0x1f1f2b0?})
	/usr/local/go/src/runtime/panic.go:920 +0x270
github.com/googleapis/cloud-bigtable-clients-test/tests.TestReadModifyWriteRow_Generic_CloseClient(0xc0000a2820)
	*******/cloud-bigtable-clients-test/tests/readmodifywriterow_test.go:339 +0xc79
testing.tRunner(0xc0000a2820, 0x1a0df18)
	/usr/local/go/src/testing/testing.go:1595 +0x262
created by testing.(*T).Run in goroutine 1
	/usr/local/go/src/testing/testing.go:1648 +0x846
exit status 2
FAIL	github.com/googleapis/cloud-bigtable-clients-test/tests	4.291s

```
**Logs after*:
```
=== RUN   TestCheckAndMutateRow_Generic_CloseClient
[Servr log] 2024/03/18 21:25:49 There is 2s sleep on the server side
[Servr log] 2024/03/18 21:25:49 There is 2s sleep on the server side
[Servr log] 2024/03/18 21:25:49 There is 2s sleep on the server side
--- PASS: TestCheckAndMutateRow_Generic_CloseClient (1.01s)
=== RUN   TestMutateRow_Generic_CloseClient
[Servr log] 2024/03/18 21:25:50 There is 2s sleep on the server side
[Servr log] 2024/03/18 21:25:50 There is 2s sleep on the server side
[Servr log] 2024/03/18 21:25:50 There is 2s sleep on the server side
--- PASS: TestMutateRow_Generic_CloseClient (1.01s)
=== RUN   TestMutateRows_Generic_CloseClient
[Servr log] 2024/03/18 21:25:51 There is 2s sleep on the server side
[Servr log] 2024/03/18 21:25:51 There is 2s sleep on the server side
[Servr log] 2024/03/18 21:25:51 There is 2s sleep on the server side
--- PASS: TestMutateRows_Generic_CloseClient (1.01s)
=== RUN   TestReadModifyWriteRow_Generic_CloseClient
[Servr log] 2024/03/18 21:25:52 There is 2s sleep on the server side
[Servr log] 2024/03/18 21:25:52 There is 2s sleep on the server side
[Servr log] 2024/03/18 21:25:52 There is 2s sleep on the server side
--- PASS: TestReadModifyWriteRow_Generic_CloseClient (1.01s)
=== RUN   TestReadRow_Generic_CloseClient
[Servr log] 2024/03/18 21:25:53 There is 2s sleep on the server side
[Servr log] 2024/03/18 21:25:53 There is 2s sleep on the server side
[Servr log] 2024/03/18 21:25:53 There is 2s sleep on the server side
--- PASS: TestReadRow_Generic_CloseClient (1.01s)
=== RUN   TestReadRows_Generic_CloseClient
[Servr log] 2024/03/18 21:25:54 There is 2s sleep on the server side
[Servr log] 2024/03/18 21:25:54 There is 2s sleep on the server side
[Servr log] 2024/03/18 21:25:54 There is 2s sleep on the server side
--- PASS: TestReadRows_Generic_CloseClient (1.01s)
=== RUN   TestSampleRowKeys_Generic_CloseClient
[Servr log] 2024/03/18 21:25:55 There is 2s sleep on the server side
[Servr log] 2024/03/18 21:25:55 There is 2s sleep on the server side
[Servr log] 2024/03/18 21:25:55 There is 2s sleep on the server side
--- PASS: TestSampleRowKeys_Generic_CloseClient (1.00s)
PASS
ok  	github.com/googleapis/cloud-bigtable-clients-test/tests	8.616s

```