### PR TITLE
fix: Various issues found in testing Ruby client

### DIFF
--- a/tests/readrow_test.go
+++ b/tests/readrow_test.go
@@ -397,5 +397,7 @@ func TestReadRow_Retry_WithRetryInfo(t *testing.T) {
 	firstReqTs := firstReq.ts.Unix()
 	retryReqTs := retryReq.ts.Unix()
 
-	assert.True(t, retryReqTs-firstReqTs >= 2)
+	delta := retryReqTs - firstReqTs
+
+	assert.True(t, delta >= 2, fmt.Sprintf("Expected retry to happen after 2ms, got %dms", delta))
 }

--- a/tests/readrows_test.go
+++ b/tests/readrows_test.go
@@ -136,10 +136,8 @@ func TestReadRows_ReverseScans_FeatureFlag_Enabled(t *testing.T) {
 	md := <-mdRecords
 
 	ff, err := getClientFeatureFlags(md)
-
 	assert.Nil(t, err, "failed to decode client feature flags")
-
-	assert.True(t, ff.ReverseScans, "client does must enable ReverseScans feature flag")
+	assert.True(t, ff != nil && ff.ReverseScans, "client does must enable ReverseScans feature flag")
 }
 
 // TestReadRows_NoRetry_OutOfOrderError_Reverse tests that client will fail on receiving out of order row keys for reverse scans.
@@ -892,8 +890,13 @@ func TestReadRows_Retry_WithRoutingCookie_MultipleErrorResponses(t *testing.T) {
 	// 4a. Verify that the read succeeds
 	checkResultOkStatus(t, res)
 	assert.Equal(t, 2, len(res.GetRows()))
-	assert.Equal(t, "row-01", string(res.Rows[0].Key))
-	assert.Equal(t, "row-05", string(res.Rows[1].Key))
+	if len(res.GetRows()) > 0 {
+		assert.Equal(t, "row-01", string(res.Rows[0].Key))
+	}
+
+	if len(res.GetRows()) > 1 {
+		assert.Equal(t, "row-05", string(res.Rows[1].Key))
+	}
 
 	// 4b. Verify routing cookie is seen
 	// Ignore the first metadata which won't have the routing cookie

--- a/tests/readrows_test.go
+++ b/tests/readrows_test.go
@@ -137,7 +137,7 @@ func TestReadRows_ReverseScans_FeatureFlag_Enabled(t *testing.T) {
 
 	ff, err := getClientFeatureFlags(md)
 	assert.Nil(t, err, "failed to decode client feature flags")
-	assert.True(t, ff != nil && ff.ReverseScans, "client does must enable ReverseScans feature flag")
+	assert.True(t, ff != nil && ff.ReverseScans, "client must enable ReverseScans feature flag")
 }
 
 // TestReadRows_NoRetry_OutOfOrderError_Reverse tests that client will fail on receiving out of order row keys for reverse scans.


### PR DESCRIPTION
Introduce a few small fixes to allow the test suite to run against the Ruby test proxy. Several tests were failing either because they waited on a channel that would not receive anything, or they attempted to read through a `nil` pointer.

The corresponding test proxy is here: https://github.com/googleapis/google-cloud-ruby/pull/25680