### PR TITLE
fix: update conformance test to determine if request is full table scan

### DIFF
--- a/tests/readrows_test.go
+++ b/tests/readrows_test.go
@@ -244,7 +244,10 @@ func TestReadRows_Retry_PausedScan(t *testing.T) {
 		origRows := origReq.req.GetRows()
 		// Check if rows or row ranges are present in requests. This is a workaround for the NodeJS client. 
 		// In Node we add an empty row range to a full table scan request to simplify the resumption logic.
-		if origRows == nil || origRows.GetRowRanges() == nil || (len(origRows.GetRowRanges()) == 1 && len(origRows.GetRowKeys()) == 0){
+		if origRows == nil || origRows.GetRowRanges() == nil {
+			// If rows don't exist in either request, skip the comparison
+			t.Logf("Skipping rows comparison: As this is a full table scan")
+		} else if len(origRows.GetRowRanges()) == 1 && origRows.GetRowRanges()[0].GetStartKey() == nil && origRows.GetRowRanges()[0].GetEndKey() == nil {
 			// If rows don't exist in either request, skip the comparison
 			t.Logf("Skipping rows comparison: As this is a full table scan")
 		} else {

--- a/tests/readrows_test.go
+++ b/tests/readrows_test.go
@@ -242,10 +242,11 @@ func TestReadRows_Retry_PausedScan(t *testing.T) {
 	retryReq := <-recorder
 	if diff := cmp.Diff(clientReq, origReq.req, protocmp.Transform(), protocmp.IgnoreEmptyMessages()); diff != "" {
 		origRows := origReq.req.GetRows()
-		// Check if rows or row ranges are present in requests
-		if origRows == nil || origRows.GetRowRanges() == nil || len(origRows.GetRowRanges()) == 1 {
+		// Check if rows or row ranges are present in requests. This is a workaround for the NodeJS client. 
+		// In Node we add an empty row range to a full table scan request to simplify the resumption logic.
+		if origRows == nil || origRows.GetRowRanges() == nil || (len(origRows.GetRowRanges()) == 1 && len(origRows.GetRowKeys()) == 0){
 			// If rows don't exist in either request, skip the comparison
-			t.Logf("Skipping comparison: As this is a full table scan")
+			t.Logf("Skipping rows comparison: As this is a full table scan")
 		} else {
 			// Otherwise, proceed with the comparison and report any differences
 			t.Errorf("diff found (-want +got):\n%s", diff) 


### PR DESCRIPTION
The NodeJS CBT client fails the `TestReadRows_Retry_PausedScan` test with the following error message:

```
(*bigtablepb.ReadRowsRequest)(Inverse(protocmp.Transform, protocmp.Message{
  	"@type":      s"google.bigtable.v2.ReadRowsRequest",
+ 	"rows":       s"{row_ranges:[{}]}",
  	"table_name": string("projects/project/instances/instance/tables/table"),
}))
```

This is due to the fact that if the original request is a full table scan, the client request will look different on a retry (the `rows` might not exist or if it does the `rows` will be an object with an empty array because there are no `row_keys`). This was causing a false diff failure in the conformance test so we're updating this conformance test to handle this edge case. 

More info at: b/380268261