### PR TITLE
fix: update check on mutateRows RPC status

### DIFF
--- a/tests/mutaterows_test.go
+++ b/tests/mutaterows_test.go
@@ -223,6 +223,7 @@ func TestMutateRows_Generic_DeadlineExceeded(t *testing.T) {
 	assert.Less(t, runTimeSecs, 8) // 8s (< 10s of server delay time) indicates timeout takes effect.
 
 	// 4c. Check the failed row
+	assert.Equal(t, int32(codes.DeadlineExceeded), res.GetStatus().GetCode())
 	assert.Equal(t, 1, len(res.GetEntries()))
 	for _, entry := range res.GetEntries() {
 		assert.Equal(t, int32(codes.DeadlineExceeded), entry.GetStatus().GetCode())

--- a/tests/mutaterows_test.go
+++ b/tests/mutaterows_test.go
@@ -223,7 +223,6 @@ func TestMutateRows_Generic_DeadlineExceeded(t *testing.T) {
 	assert.Less(t, runTimeSecs, 8) // 8s (< 10s of server delay time) indicates timeout takes effect.
 
 	// 4c. Check the failed row
-	checkResultOkStatus(t, res)
 	assert.Equal(t, 1, len(res.GetEntries()))
 	for _, entry := range res.GetEntries() {
 		assert.Equal(t, int32(codes.DeadlineExceeded), entry.GetStatus().GetCode())


### PR DESCRIPTION
This test is testing the following behavior:

1. client sends a mutateRows request with 2 second deadline
2. Server hangs for 10 seconds
3. Client deadline passes and the request failed with deadline exceeded error.

In this case the RPC should fail with DEADLINE_EXCEEDED and the entries should fail with deadline exceeded too. Therefore this check is incorrect and test-proxy implementations (for example java) populates a fake status code https://github.com/googleapis/java-bigtable/blob/main/test-proxy/src/main/java/com/google/cloud/bigtable/testproxy/CbtTestProxy.java#L331.

Update the check to reflect expected client behavior. Note that test proxy needs to be updated after this is merged.