### PR TITLE
fix: Check mutation error only if exists

### DIFF
--- a/tests/mutaterows_test.go
+++ b/tests/mutaterows_test.go
@@ -224,9 +224,11 @@ func TestMutateRows_Generic_DeadlineExceeded(t *testing.T) {
 
 	// 4c. Check the failed row
 	assert.Equal(t, int32(codes.DeadlineExceeded), res.GetStatus().GetCode())
-	assert.Equal(t, 1, len(res.GetEntries()))
-	for _, entry := range res.GetEntries() {
-		assert.Equal(t, int32(codes.DeadlineExceeded), entry.GetStatus().GetCode())
+	if len(res.GetEntries()) != 0 {
+		assert.Equal(t, 1, len(res.GetEntries()))
+		for _, entry := range res.GetEntries() {
+			assert.Equal(t, int32(codes.DeadlineExceeded), entry.GetStatus().GetCode())
+		}
 	}
 }
 
@@ -339,13 +341,13 @@ func TestMutateRows_Retry_ExponentialBackoff(t *testing.T) {
 
 	for n := 1; n < numRPCs; n += 1 {
 		select {
-		case retry := <- recorder:
+		case retry := <-recorder:
 			delay := int(retry.ts.UnixMilli() - origReq.ts.UnixMilli())
 			// Different clients may have different behaviors, we log the delays for informational purpose.
 			// Example: For the first retry delay, C++ client uses 100ms but Java client uses 10ms.
 			t.Logf("Retry #%d delay: %dms", n, delay)
 		case <-time.After(500 * time.Millisecond):
-			t.Logf("Retry #%d: Timeout waiting for retry (expecting %d retries)", n, numRPCs - 1)
+			t.Logf("Retry #%d: Timeout waiting for retry (expecting %d retries)", n, numRPCs-1)
 		}
 	}
 }
@@ -477,7 +479,7 @@ func TestMutateRows_Retry_WithRoutingCookie(t *testing.T) {
 	mdRecorder := make(chan metadata.MD, 2)
 	actions := []*mutateRowsAction{
 		&mutateRowsAction{rpcError: codes.Unavailable, routingCookie: cookie},
-		&mutateRowsAction{data: buildEntryData([]int{0}, nil, 0),},
+		&mutateRowsAction{data: buildEntryData([]int{0}, nil, 0)},
 	}
 	server := initMockServer(t)
 	server.MutateRowsFn = mockMutateRowsFnWithMetadata(recorder, mdRecorder, actions)
@@ -507,7 +509,7 @@ func TestMutateRows_Retry_WithRoutingCookie(t *testing.T) {
 			return
 		}
 		assert.Equal(t, cookie, val[0])
-	case <- time.After(100 * time.Millisecond):
+	case <-time.After(100 * time.Millisecond):
 		t.Error("Timeout waiting for requests on recorder channel")
 	}
 }
@@ -523,7 +525,7 @@ func TestMutateRows_Retry_WithRetryInfo(t *testing.T) {
 	mdRecorder := make(chan metadata.MD, 2)
 	actions := []*mutateRowsAction{
 		&mutateRowsAction{rpcError: codes.Unavailable, retryInfo: "2s"},
-		&mutateRowsAction{data: buildEntryData([]int{0}, nil, 0),},
+		&mutateRowsAction{data: buildEntryData([]int{0}, nil, 0)},
 	}
 	server := initMockServer(t)
 	server.MutateRowsFn = mockMutateRowsFnWithMetadata(recorder, mdRecorder, actions)


### PR DESCRIPTION
TestMutateRows_Generic_DeadlineExceeded fails for Go client library with below error

```
=== RUN   TestMutateRows_Generic_DeadlineExceeded
[Servr log] 2025/01/15 19:19:42 There is 10s sleep on the server side
2025/01/15 19:19:44 received error from Table.ApplyBulk(): rpc error: code = DeadlineExceeded desc = context deadline exceeded
2025/01/15 19:19:44 error: rpc error: code = DeadlineExceeded desc = context deadline exceeded
    mutaterows_test.go:227: 
        	Error Trace:	/home/runner/work/google-cloud-go/google-cloud-go/cloud-bigtable-clients-test/tests/mutaterows_test.go:227
        	Error:      	Not equal: 
        	            	expected: 1
        	            	actual  : 0
        	Test:       	TestMutateRows_Generic_DeadlineExceeded
--- FAIL: TestMutateRows_Generic_DeadlineExceeded (2.00s)
```

This [test](https://github.com/googleapis/cloud-bigtable-clients-test/blob/v0.0.3/tests/mutaterows_test.go#L188) expects overall operation to return error and also per mutation error but in Go, method is [documented](https://github.com/googleapis/google-cloud-go/blob/bigtable/v1.34.0/bigtable/bigtable.go#L1236-L1239) as below:

```
// If the entire process
// fails, (nil, err) will be returned. If specific mutations
// fail to apply, ([]err, nil) will be returned, and the errors
// will correspond to the relevant rowKeys/muts arguments.
```
So, I can't return ([]err, err) from Go library ApplyBulk method. This may break user's code.

Thus, updating the test itself